### PR TITLE
Simplify grading rubric and logic

### DIFF
--- a/grade_review_prompt.txt
+++ b/grade_review_prompt.txt
@@ -1,20 +1,26 @@
-You are an independent moderator tasked with verifying the fairness of AI-generated grades. Review the student's submission alongside the AI's YAML grade breakdown.
-If you find no issues, respond with "No issues found."
-If you identify issues, provide your feedback as a list.
-For each criterion that needs a band change, add a line with ADJUSTMENT: [criterion_id] -> [new_band_number].
-If the overall grade should change, add a final line: RECOMMENDED_GRADE: [A-E]
+You are a senior moderator reviewing a grade assigned by a junior AI marker.
+Your task is to check the AI's work for fairness, accuracy, and adherence to the rubric.
 
-EXAMPLE OUTPUT
-The 'treatment' section seems graded too harshly. The student proposed CBTp which is evidence-based. Evidence: "My calculated treatment approach for Sam D is a combination of CBTp..."
-ADJUSTMENT: treatment -> 4
-The 'communication' band is too high. The submission is over the word limit.
-ADJUSTMENT: communication -> 2
-RECOMMENDED_GRADE: B
-
-STUDENT_SUBMISSION
+First, here is the student's submission:
+---
 {{STUDENT_SUBMISSION_TEXT_HERE}}
+---
 
-AI_GRADE_YAML
+And here is the junior AI's YAML-formatted grade and reasoning:
+---
 {{AI_GRADE_YAML_HERE}}
+---
 
-YOUR REVIEW OUTPUT:
+### YOUR TASK
+
+1.  Review the student's work and the AI's assessment.
+2.  Do you agree with the AI's assigned bands (from 1-5) for each criterion?
+3.  Provide a brief overall summary of your findings.
+4.  **If you believe a band should be changed, you MUST state it in the following format, each on a new line:**
+    `ADJUSTMENT: [criterion_id] -> [new_band_number]`
+
+### EXAMPLE OF YOUR RESPONSE:
+
+Overall, the AI's grading is fair. However, it was too harsh on the differential diagnosis.
+
+ADJUSTMENT: diagnostic_diff -> 4

--- a/rubric.yml
+++ b/rubric.yml
@@ -1,41 +1,34 @@
-rubric_name: "Year-10 Case-Study Diagnostic Task"
-total_points_possible: 25
-word_count:
-  min: 750
-  max: 1250
+# Simplified 30-Point Rubric
+
+total_points_possible: 30
+
+# Defines the name and maximum points for each criterion.
+# The 'band' (1-5) from the AI will be treated as the 'points' achieved.
 criteria:
   symptom_analysis:
     name: "Knowledge & Symptom Analysis"
     max_points: 5
   bps_factors:
-    name: "Biological, Psychological & Social Factors"
-    max_points: 4
+    name: "Bio-Psycho-Social Factors"
+    max_points: 5
   diagnostic_primary:
-    name: "Primary Diagnosis Accuracy & Justification"
-    max_points: 4
+    name: "Diagnostic Reasoning (Primary)"
+    max_points: 5
   diagnostic_diff:
-    name: "Differential Diagnosis Reasoning"
-    max_points: 4
+    name: "Differential Diagnosis"
+    max_points: 5
   treatment:
-    name: "Treatment Selection & Justification"
+    name: "Treatment & Justification"
     max_points: 5
   communication:
     name: "Communication & Referencing"
-    max_points: 3
-rules:
-  - name: "Word-count ceiling"
-    condition: "word_count < 750 or word_count > 1250"
-    action: "set_band"
-    target: "communication"
-    band: 2
-  - name: "Primary diagnosis incorrect"
-    condition: "diagnostic_primary_band < 3"
-    action: "cap_points"
-    target: "treatment"
-    points: 3
+    max_points: 5
+
+# Optional: Maps the final point score to a letter grade.
+# Thresholds represent the minimum points needed for that grade.
 grade_bands:
-  A: 20
-  B: 15
-  C: 12
-  D_ratio: 0.4
-  E_ratio: 0.2
+  A: 27  # 90%
+  B: 24  # 80%
+  C: 21  # 70%
+  D: 18  # 60%
+  E: 0   # Below 60%


### PR DESCRIPTION
## Summary
- simplify `rubric.yml` to a 30‑point rubric
- update grade review prompt with clearer adjustment instructions
- refactor grading logic in `grader.py` to drop complex rules
- remove obsolete grade override flow

## Testing
- `python -m py_compile grader.py`

------
https://chatgpt.com/codex/tasks/task_e_685a2265868883279ced3397e7c32062