### PR TITLE
Revise rubric and display descriptors

### DIFF
--- a/grader.py
+++ b/grader.py
@@ -467,6 +467,7 @@ def format_feedback_as_docx(
             cid: {
                 "name": cfg.get("name", cid),
                 "max_points": cfg.get("max_points", 0),
+                "descriptors": cfg.get("descriptors", {}),
             }
             for cid, cfg in rubric_config.get("criteria", {}).items()
         }
@@ -491,6 +492,16 @@ def format_feedback_as_docx(
 
             doc.add_paragraph(f"Band Achieved: {band}")
             doc.add_paragraph(f"Points: {points_achieved} / {max_criterion_points}")
+
+            descriptors = criterion_details.get("descriptors", {})
+            if descriptors:
+                desc_text = descriptors.get(str(band))
+                if desc_text:
+                    doc.add_paragraph(
+                        f"Rubric Descriptor for Band {band}:",
+                        style="Intense Quote",
+                    )
+                    doc.add_paragraph(desc_text)
 
             doc.add_paragraph("AI's Rationale:", style="Intense Quote")
             doc.add_paragraph(rationale)

--- a/master_prompt.txt
+++ b/master_prompt.txt
@@ -1,11 +1,11 @@
 ### Student-Facing Rubric (Concise)
-Criterion       A       B       C       D       E
-Knowledge & Symptom Analysis    Precise definition; ≥5 normal and ≥5 disorder-related experiences correctly classified and justified.   Mostly accurate classification; minor gaps.     Basic explanation; some errors.  Limited/confused classification.        Inaccurate or missing.
-B-P-S Factors   Biological, psychological and social factors clearly linked and interacting.    Most factors linked; minor gaps.        Factors listed; weak links.     Few factors; unclear links.     Incorrect / missing.
-Diagnostic Reasoning (primary)  DSM-5 criteria mapped, duration justified; diagnosis airtight.  Accurate, minor omissions.      Plausible but partial mapping. Weak or incorrect diagnosis.     Absent.
-Differential Diagnosis  Plausible secondary disorder; clear comparison. Good secondary, minor gaps.     Named but weak comparison.      Inappropriate / minimalAbsent.
-Treatment & Justification       Evidence-based therapy/meds; detailed links to symptoms.        Appropriate; good links.        Suitable; generic links.       Partly unsuitable or vague.      Absent/incorrect.
-Communication & Referencing     Clear structure, fluent writing, correct APA/Harvard, 0–1 errors, 800–1200 w.   Mostly clear; ≤3 errors.        Adequate; several errors; minor word-count drift.       Disorganised; frequent errors.  Ineffective or plagiarised.
+Criterion       5 (Excellent)  4 (Good)  3 (Adequate)  2 (Limited)  1 (Not Present)
+Knowledge & Symptom Analysis    Clear definition of "psychological disorder" noting distress/impairment; correctly classifies ≥5 normal and ≥5 disorder experiences with justification.    Good definition; most symptoms classified correctly with minor issues.    Basic or simplified definition with several classification errors or omissions.    Vague or incorrect definition with minimal or inaccurate classification.    Section missing or irrelevant.
+B-P-S Factors   Identifies biological, psychological and social factors and clearly explains how they interact.    Factors from all domains with brief or superficial interaction explanation.    Factors from at least two domains with little connection.    Factors from only one domain or largely incorrect.    Section missing.
+Diagnostic Reasoning (Primary)  Correct, well-supported diagnosis mapping evidence to each DSM criterion including duration.    Correct diagnosis with reasonable but incomplete mapping.    Plausible diagnosis with weak or vague justification.    Incorrect or poorly supported diagnosis.    No primary diagnosis provided.
+Differential Diagnosis  Plausible alternative disorder clearly ruled out with evidence.    Plausible alternative with weaker comparison.    Alternative named with minimal comparison.    Inappropriate or illogical alternative.    Not provided.
+Treatment & Justification       Recommends specific evidence-based treatments with detailed links to symptoms.    Appropriate treatments with generic justification.    Suitable treatment mentioned with little explanation.    Vague or inappropriate treatment recommendation.    No treatment plan provided.
+Communication & Referencing     Clear academic writing and structure; almost no language errors; correct referencing.    Mostly clear with minor errors.    Understandable but disorganised with several errors.    Difficult to follow with frequent errors or referencing issues.    Incoherent or plagiarised.
 
 ### SYSTEM
 You are a strict marker for Year-10 Psychology case-study tasks. You will analyze the student's submission against a detailed rubric. Your task is to assess each criterion, assign a band from 1 to 5, and provide a concise rationale for your decision.

--- a/rubric.yml
+++ b/rubric.yml
@@ -8,21 +8,57 @@ criteria:
   symptom_analysis:
     name: "Knowledge & Symptom Analysis"
     max_points: 5
+    descriptors:
+      "5": "Excellent: Provides a clear, textbook-level definition of 'psychological disorder' that explicitly mentions distress and/or impairment. Correctly classifies at least 5 normal and 5 disorder-related experiences from the case study with clear justification for each."
+      "4": "Good: Defines psychological disorder well but the definition may be less precise or miss a key component (like impairment). Correctly classifies most symptoms but may have minor errors or weaker justifications."
+      "3": "Adequate: Provides a basic or overly simple definition of a psychological disorder. Attempts to classify symptoms but has several errors or omissions (e.g., fewer than 3-4 examples for each category)."
+      "2": "Limited: The definition is vague, incorrect, or missing. Symptom classification is minimal, confused, or largely inaccurate."
+      "1": "Not Present: This section is missing or contains no relevant information."
   bps_factors:
     name: "Bio-Psycho-Social Factors"
     max_points: 5
+    descriptors:
+      "5": "Excellent: Clearly identifies relevant factors in all three domains (Biological, Psychological, Social) and explains in detail how they interact with each other to contribute to the disorder (e.g., a feedback loop)."
+      "4": "Good: Identifies factors in all three domains and attempts to explain their interaction, but the explanation is superficial or less detailed."
+      "3": "Adequate: Lists factors from at least two of the three domains but provides little to no explanation of how they interact or connect."
+      "2": "Limited: Identifies factors from only one domain, or the identified factors are incorrect or irrelevant to the case study."
+      "1": "Not Present: This section is missing."
   diagnostic_primary:
     name: "Diagnostic Reasoning (Primary)"
     max_points: 5
+    descriptors:
+      "5": "Excellent: Proposes a correct and well-supported primary diagnosis. Systematically maps specific evidence from the case study to each of the necessary DSM-5 (or relevant) criteria, including duration."
+      "4": "Good: Proposes a correct diagnosis with good justification, but the mapping to official criteria is less thorough or may miss a criterion (like duration)."
+      "3": "Adequate: Proposes a plausible diagnosis, but the justification is weak, vague, or simply restates symptoms without linking them to specific diagnostic criteria."
+      "2": "Limited: Proposes an incorrect or very poorly supported diagnosis."
+      "1": "Not Present: No primary diagnosis is provided."
   diagnostic_diff:
     name: "Differential Diagnosis"
     max_points: 5
+    descriptors:
+      "5": "Excellent: Identifies a plausible alternative disorder and provides a clear, evidence-based argument explaining why it is less likely than the primary diagnosis, effectively 'ruling it out'."
+      "4": "Good: Identifies a plausible alternative and makes a reasonable comparison, but the argument for ruling it out is less convincing or lacks strong evidence from the case."
+      "3": "Adequate: Names a plausible alternative disorder but offers a minimal or very weak comparison to the primary diagnosis."
+      "2": "Limited: Names an inappropriate or highly unlikely alternative disorder, or the comparison is nonsensical."
+      "1": "Not Present: No differential diagnosis is provided."
   treatment:
     name: "Treatment & Justification"
     max_points: 5
+    descriptors:
+      "5": "Excellent: Recommends specific, evidence-based treatments (e.g., CBT, specific medications) and provides a detailed justification explaining how each treatment component targets specific symptoms identified earlier in the analysis."
+      "4": "Good: Recommends appropriate, evidence-based treatments, but the justification is more generic and less connected to the specific symptoms of the case."
+      "3": "Adequate: Recommends a suitable treatment (e.g., 'therapy') but with little or no specific justification."
+      "2": "Limited: Recommends a vague, inappropriate, or outdated treatment."
+      "1": "Not Present: No treatment plan is provided."
   communication:
     name: "Communication & Referencing"
     max_points: 5
+    descriptors:
+      "5": "Excellent: Writing is clear, well-structured, and uses an academic tone. There are virtually no spelling or grammar errors. Referencing (e.g., APA/Harvard) is present and correctly formatted."
+      "4": "Good: Writing is mostly clear and structured. There may be a few minor errors in spelling, grammar, or referencing format."
+      "3": "Adequate: The structure is understandable but may be disorganized in places. There are several noticeable errors in grammar or referencing that may slightly hinder clarity."
+      "2": "Limited: The writing is difficult to follow due to poor structure, frequent errors, or major referencing issues. Word count rules may be significantly breached."
+      "1": "Not Present: The submission is incoherent, appears to be plagiarized, or is missing."
 
 # Optional: Maps the final point score to a letter grade.
 # Thresholds represent the minimum points needed for that grade.


### PR DESCRIPTION
## Summary
- expand rubric.yml with detailed descriptors for every band
- replace the rubric text in `master_prompt.txt`
- show rubric descriptor text in generated DOCX reports

## Testing
- `python -m py_compile grader.py`
- `python -m py_compile draft_grader.py`


------
https://chatgpt.com/codex/tasks/task_e_685a2b08b6488327a052a890cb9059bb