### PR TITLE
Fix grade bands mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Each script processes all files in `input_assessments/` and writes DOCX reports 
 
 ## Grade Calculation
 
-The overall grade in each report is derived from the rubric points returned by the AI. All points from `assistant_grade.breakdown` are summed (out of 30). Scores of **24–30** receive an **A**, **18–23** a **B** and **14–17** a **C**. Scores below 14 fall back to the original band mapping for **D** or **E**.
+The overall grade in each report is derived from the rubric points returned by the AI. All points from `assistant_grade.breakdown` are summed (out of 30). Scores of **27–30** receive an **A**, **24–26** a **B**, **21–23** a **C**, and **18–20** a **D**. Anything below 18 is graded **E**.
 
 Each DOCX report lists the grade suggested by the AI (`assistant_grade.overall_grade`) alongside the grade calculated from the rubric totals. If the two differ, the final grade shown is the one based on the rubric points and a short note explains that the grade was adjusted accordingly.
 

--- a/grader.py
+++ b/grader.py
@@ -313,7 +313,11 @@ def parse_gemini_yaml_response(response_text):
 
 
 def compute_overall_grade(total_points, grade_bands, total_possible):
-    """Compute a letter grade from a total point score based on thresholds."""
+    """Compute a letter grade from a total point score based on thresholds.
+
+    The default mapping for the 30-point rubric is:
+        27–30 = A, 24–26 = B, 21–23 = C, 18–20 = D, below 18 = E.
+    """
     if not isinstance(total_points, (int, float)) or not isinstance(grade_bands, dict):
         return "N/A"
 


### PR DESCRIPTION
## Summary
- update README grade thresholds to match rubric
- document default grade mapping in `compute_overall_grade`

## Testing
- `python -m py_compile grader.py draft_grader.py`

------
https://chatgpt.com/codex/tasks/task_e_685a3a02115c83278581affb27bf548a