### PR TITLE
Add unit tests and pytest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Each DOCX report lists the grade suggested by the AI (`assistant_grade.overall_g
 - PDF text extraction uses `PyPDF2`; encrypted or malformed PDFs may fail.
 - DOCX extraction now captures text inside tables.
 - The repository currently includes a Windows-based `venv` directory which can be removed if you prefer to create your own environment.
-- There are no automated tests.
+- Automated tests are provided under the `tests/` directory. Run them with:
+
+```bash
+python -m pytest
+```
 - Each run of `draft_grader.py` also outputs a `_feedback_review.txt` file summarising any inaccuracies in the AI feedback or areas already addressed in the submission.
 - Running `grader.py` performs a second pass to verify the grading. The result is saved as a `_grade_review.txt` file alongside each report, and a `grading_summary.csv` file summarises total points and grades.

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1,0 +1,46 @@
+import yaml
+from pathlib import Path
+import pytest
+
+from grader import compute_overall_grade, calculate_final_grade
+
+
+@pytest.fixture
+def rubric_config():
+    rubric_path = Path(__file__).resolve().parents[1] / "rubric.yml"
+    with open(rubric_path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+@pytest.mark.parametrize(
+    "points,expected",
+    [
+        (28, "A"),
+        (24, "B"),
+        (23, "C"),
+        (18, "D"),
+        (5, "E"),
+    ],
+)
+def test_compute_overall_grade(points, expected, rubric_config):
+    bands = rubric_config["grade_bands"]
+    total_possible = rubric_config["total_points_possible"]
+    assert compute_overall_grade(points, bands, total_possible) == expected
+
+
+def test_calculate_final_grade_mock():
+    rubric = {
+        "criteria": {
+            "c1": {"max_points": 5},
+            "c2": {"max_points": 5},
+        },
+        "grade_bands": {"A": 9, "B": 8, "C": 6, "D": 5, "E": 0},
+        "total_points_possible": 10,
+    }
+    bands_data = {"c1": 5, "c2": 4}
+    result = calculate_final_grade(bands_data, 100, rubric)
+
+    assert result["total_points"] == 9
+    assert result["overall_grade"] == "A"
+    assert result["breakdown"]["c1"] == {"band": 5, "points": 5}
+    assert result["breakdown"]["c2"] == {"band": 4, "points": 4}


### PR DESCRIPTION
## Summary
- add `tests/` with pytest coverage for grade calculations
- document running tests in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3a0e7aa083278ccfbbecaeef5a8f